### PR TITLE
make `NotAuthentic` error public API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ use std::io;
 use std::io::Write;
 
 pub use self::aead::{Aad, Algorithm, Key, Nonce};
-pub use self::error::Invalid;
+pub use self::error::{Invalid, NotAuthentic};
 
 mod aead;
 mod error;


### PR DESCRIPTION

<!-- 
If you want to add a feature or fix a bug (not just typos / code style / ...),
please open an issue first such that we can discuss the feature and track bugs.
See: https://github.com/secure-io/sio-go/issues
Thank you :)
-->

#### What does the PR do?
This commit makes the `NotAuthentic` error type
public API. This is necessary b/c otherwise external code
cannot implement the `Algorithm` trait and consequently
define/implement new/other AEAD (implementations).


#### What problem does it solve?
Currently no external code can implement `sio::Algorithm`.




<!-- Thank you very much for contributing to this project! -->
