### PR TITLE
Refactor writer

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,34 +1,47 @@
-use std::error::Error;
-use std::{fmt, io};
+use std::{error::Error, fmt, io};
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+/// An error indicating that the encrypted data is not authentic - e.g.
+/// malisously modified.
+///
+/// It happens whenever the decryption of some ciphertext fails.
+#[derive(Clone, Copy, PartialEq)]
 pub struct NotAuthentic;
 
 impl NotAuthentic {
     const fn description() -> &'static str {
-        "not authentic"
+        "data is not authentic"
     }
 }
 
 impl Error for NotAuthentic {
+    #[inline]
     fn description(&self) -> &str {
         Self::description()
     }
 }
 
+impl fmt::Debug for NotAuthentic {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", Self::description())
+    }
+}
+
 impl fmt::Display for NotAuthentic {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", Self::description())
     }
 }
 
 impl From<NotAuthentic> for io::Error {
+    #[inline]
     fn from(_: NotAuthentic) -> Self {
         io::Error::new(io::ErrorKind::InvalidData, NotAuthentic)
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, PartialEq)]
 pub struct Exceeded;
 
 impl Exceeded {
@@ -38,18 +51,28 @@ impl Exceeded {
 }
 
 impl Error for Exceeded {
+    #[inline]
     fn description(&self) -> &str {
         Self::description()
     }
 }
 
 impl fmt::Display for Exceeded {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", Self::description())
+    }
+}
+
+impl fmt::Debug for Exceeded {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", Self::description())
     }
 }
 
 impl From<Exceeded> for io::Error {
+    #[inline]
     fn from(_: Exceeded) -> Self {
         io::Error::new(io::ErrorKind::InvalidData, Exceeded)
     }


### PR DESCRIPTION
<!-- 
If you want to add a feature or fix a bug (not just typos / code style / ...),
please open an issue first such that we can discuss the feature and track bugs.
See: https://github.com/secure-io/sio-go/issues
Thank you :)
-->

#### What does the PR do?
This PR consists of two commits:
 - refactor {Enc/Dec}Writer to use Box<[u8]> instead of Vec<u8>
  This commit replaces the buffer in {Enc/Dec}Writer with a
  Box<[u8]>. The reason is that non-sophisticated benchmarks
  showed that truncating the Vec after a write to the inner
  writer were relatively expensive.  
  Further, this commit improves the `Counter<A>` implementation
  such that it now returns just a reference to the nonce
  instead of allocating and copying a new one per fragment.
- implement `Debug` trait explicitly for NotAuthentic and Exceeded
  This commit implements the `Debug` trait for `NotAuthentic`
  and `Exceeded` explicitly such that the printed output
  is guaranteed to be equal. Further, it adds some `#[inline]`
  directives.

#### What problem does it solve?
It improves the performance of `EncWriter` / `DecWriter` and ensures that the printed error output for
`NotAuthentic` and `Exceeded` is always equal.




<!-- Thank you very much for contributing to this project! -->
