### PR TITLE
handle non-closed Enc/DecWriter in Drop impl.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,17 @@ description = "Secure IO"
 license = "MIT"
 
 [features]
-default = ["ring"]
+default = ["ring", "must_close"]
+
+# The 'must_close' feature ensures that an EncWriter
+# or DecWriter is actually closed by an explicit
+# invocation of the 'close()' method. If an EncWriter
+# or DecWriter gets dropped without being closed
+# explicitly, its destructor will panic at runtime.
+#
+# This feature is enabled by default. Disabling it
+# only affects debug builds.
+must_close = []
 
 [dependencies]
 ring = { version = "0.14.6", optional = true }


### PR DESCRIPTION


<!-- 
If you want to add a feature or fix a bug (not just typos / code style / ...),
please open an issue first such that we can discuss the feature and track bugs.
See: https://github.com/secure-io/sio-go/issues
Thank you :)
-->

#### What does the PR do?
This commit changes the behavior of the Drop implementation
for EncWriter and DecWriter such that the destructor panics
if the writer was not closed explicitly.

In general, a constructor should not panic. However, not doing
so when the writer hasn't been closed may cause silent data corruption.
In cryptographic code we cannot do the same optimistic approach
like e.g. std::io::BufWriter. Not calling `close()` is considered a
logic bug. Ideally, we would like to raise a compiler error when a
Enc/DecWriter is not closed but that implies that the compiler *proofs*
statically that the writer is *always* closed. Even though that may be
possible for the most cases (e.t. requiring complex analysis) it may
not be possible all the time... (Threads?!) - Anyway, if it turns out
that we can do this - we should!

However, for debugging purposes we may want to disable the panic to e.g.
debug a panic that occurs between creating an Enc/DecWriter and closing
it. (Dropping the writer causes another panic and we loose the
information from the first one...). Therefore, there is the feature
`must_close` which is enabled by default and disabling it only affects
debug builds.

Further, the close function is now annotated by the `must_use` attribute
since only after close you can tell whether i.e. decryption was
successful.

#### What problem does it solve?
<!-- For features and (major) bug fixes link the issue here (e.g. #42) ->




<!-- Thank you very much for contributing to this project! -->
