### PR TITLE
add benchmarks for EncWriter and DecWriter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,16 @@ edition = "2018"
 description = "Secure IO"
 license = "MIT"
 
+[profile.bench]
+opt-level = 3
+debug = false
+rpath = false
+lto = true
+debug-assertions = false
+codegen-units = 16
+incremental = false
+overflow-checks = false
+
 [features]
 default = ["ring", "must_close"]
 

--- a/benches/writer.rs
+++ b/benches/writer.rs
@@ -1,0 +1,209 @@
+#![feature(test)]
+
+use sio::{ring::*, *};
+use std::{io, io::Write};
+
+extern crate test;
+use test::Bencher;
+
+type AEAD = AES_256_GCM;
+
+fn buffer_size() -> usize {
+    if let Ok(value) = std::env::var("SIO_BUF_SIZE") {
+        let value: usize = value
+            .as_str()
+            .parse()
+            .expect("'SIO_BUF_SIZE' is not a number");
+        1024 * value
+    } else {
+        sio::BUF_SIZE
+    }
+}
+
+#[bench]
+fn encrypt_write_1k(b: &mut Bencher) -> io::Result<()> {
+    let key: Key<AEAD> = Key::new([0; Key::<AEAD>::SIZE]);
+    let mut writer = EncWriter::with_buffer_size(
+        io::sink(),
+        &key,
+        Nonce::new([0; Nonce::<AEAD>::SIZE]),
+        Aad::empty(),
+        buffer_size(),
+    )
+    .expect("Failed to create EncWriter");
+
+    let buf: &[u8] = &[0; 1 * 1024];
+    b.bytes = 1 * 1024;
+    b.iter(|| {
+        writer.write_all(buf).expect("encryption failed");
+    });
+    writer.close()
+}
+
+#[bench]
+fn encrypt_write_64k(b: &mut Bencher) -> io::Result<()> {
+    let key: Key<AEAD> = Key::new([0; Key::<AEAD>::SIZE]);
+    let mut writer = EncWriter::with_buffer_size(
+        io::sink(),
+        &key,
+        Nonce::new([0; Nonce::<AEAD>::SIZE]),
+        Aad::empty(),
+        buffer_size(),
+    )
+    .expect("Failed to create EncWriter");
+
+    let buf: &[u8] = &[0; 64 * 1024];
+    b.bytes = 64 * 1024;
+    b.iter(|| {
+        writer.write_all(buf).expect("encryption failed");
+    });
+    writer.close()
+}
+
+#[bench]
+fn encrypt_write_512k(b: &mut Bencher) -> io::Result<()> {
+    let key: Key<AEAD> = Key::new([0; Key::<AEAD>::SIZE]);
+    let mut writer = EncWriter::with_buffer_size(
+        io::sink(),
+        &key,
+        Nonce::new([0; Nonce::<AEAD>::SIZE]),
+        Aad::empty(),
+        buffer_size(),
+    )
+    .expect("Failed to create EncWriter");
+
+    let buf: &[u8] = &[0; 512 * 1024];
+    b.bytes = 512 * 1024;
+    b.iter(|| {
+        writer.write_all(buf).expect("encryption failed");
+    });
+    writer.close()
+}
+
+#[bench]
+fn encrypt_write_1mb(b: &mut Bencher) -> io::Result<()> {
+    let key: Key<AEAD> = Key::new([0; Key::<AEAD>::SIZE]);
+    let mut writer = EncWriter::with_buffer_size(
+        io::sink(),
+        &key,
+        Nonce::new([0; Nonce::<AEAD>::SIZE]),
+        Aad::empty(),
+        buffer_size(),
+    )
+    .expect("Failed to create EncWriter");
+
+    let buf: &[u8] = &[0; 1024 * 1024];
+    b.bytes = 1024 * 1024;
+    b.iter(|| {
+        writer.write_all(buf).expect("encryption failed");
+    });
+    writer.close()
+}
+
+#[bench]
+fn decrypt_write_1k(b: &mut Bencher) -> io::Result<()> {
+    let key: Key<AEAD> = Key::new([0; Key::<AEAD>::SIZE]);
+    let mut writer = EncWriter::with_buffer_size(
+        DecWriter::with_buffer_size(
+            io::sink(),
+            &key,
+            Nonce::new([0; Nonce::<AEAD>::SIZE]),
+            Aad::empty(),
+            buffer_size(),
+        )
+        .expect("Failed to create DecWriter"),
+        &key,
+        Nonce::new([0; Nonce::<AEAD>::SIZE]),
+        Aad::empty(),
+        buffer_size(),
+    )
+    .expect("Failed to create EncWriter");
+    let buf: &[u8] = &[0; 512];
+
+    b.bytes = 1024;
+    b.iter(|| {
+        writer.write_all(buf).expect("decryption failed");
+    });
+    writer.close()
+}
+
+#[bench]
+fn decrypt_write_64k(b: &mut Bencher) -> io::Result<()> {
+    let key: Key<AEAD> = Key::new([0; Key::<AEAD>::SIZE]);
+    let mut writer = EncWriter::with_buffer_size(
+        DecWriter::with_buffer_size(
+            io::sink(),
+            &key,
+            Nonce::new([0; Nonce::<AEAD>::SIZE]),
+            Aad::empty(),
+            buffer_size(),
+        )
+        .expect("Failed to create DecWriter"),
+        &key,
+        Nonce::new([0; Nonce::<AEAD>::SIZE]),
+        Aad::empty(),
+        buffer_size(),
+    )
+    .expect("Failed to create EncWriter");
+    let buf: &[u8] = &[0; 32 * 1024];
+
+    b.bytes = 64 * 1024;
+    b.iter(|| {
+        writer.write_all(buf).expect("decryption failed");
+    });
+    writer.close()
+}
+
+#[bench]
+fn decrypt_write_512k(b: &mut Bencher) -> io::Result<()> {
+    let key: Key<AEAD> = Key::new([0; Key::<AEAD>::SIZE]);
+    let mut writer = EncWriter::with_buffer_size(
+        DecWriter::with_buffer_size(
+            io::sink(),
+            &key,
+            Nonce::new([0; Nonce::<AEAD>::SIZE]),
+            Aad::empty(),
+            buffer_size(),
+        )
+        .expect("Failed to create DecWriter"),
+        &key,
+        Nonce::new([0; Nonce::<AEAD>::SIZE]),
+        Aad::empty(),
+        buffer_size(),
+    )
+    .expect("Failed to create EncWriter");
+    let buf: &[u8] = &[0; 256 * 1024];
+
+    b.bytes = 512 * 1024;
+    b.iter(|| {
+        writer.write_all(buf).expect("decryption failed");
+    });
+    writer.close()
+}
+
+#[bench]
+fn decrypt_write_1mb(b: &mut Bencher) -> io::Result<()> {
+    let key: Key<AEAD> = Key::new([0; Key::<AEAD>::SIZE]);
+    let mut writer = EncWriter::with_buffer_size(
+        DecWriter::with_buffer_size(
+            io::sink(),
+            &key,
+            Nonce::new([0; Nonce::<AEAD>::SIZE]),
+            Aad::empty(),
+            buffer_size(),
+        )
+        .expect("Failed to create DecWriter"),
+        &key,
+        Nonce::new([0; Nonce::<AEAD>::SIZE]),
+        Aad::empty(),
+        buffer_size(),
+    )
+    .expect("Failed to create EncWriter");
+
+    let buf: &[u8] = &[0; 512 * 1024];
+    b.bytes = 1024 * 1024;
+    b.iter(|| {
+        writer.write_all(buf).expect("decryption failed");
+    });
+    writer.close()
+}


### PR DESCRIPTION

<!-- 
If you want to add a feature or fix a bug (not just typos / code style / ...),
please open an issue first such that we can discuss the feature and track bugs.
See: https://github.com/secure-io/sio-go/issues
Thank you :)
-->

#### What does the PR do?
This commit adds benchmarks for encryption
and decryption. With the `SIO_BUF_SIZE` env.
var. (in KiB) it is possible to customize use different
buffer sizes. If `SIO_BUF_SIZE` is not present the default
buffer size is used.

On important caveat is that decryption benchmarks only process
half the amount of data. The reason is that the data gets encrypted
first and then decrypted again. So, decryption benchmarks may not be
100% accurate.


#### What problem does it solve?
<!-- For features and (major) bug fixes link the issue here (e.g. #42) ->




<!-- Thank you very much for contributing to this project! -->
