### PR TITLE
make benchmark buffer size env. var. a constant

### DIFF
--- a/benches/writer.rs
+++ b/benches/writer.rs
@@ -1,6 +1,6 @@
 #![feature(test)]
 
-use sio::{ring::*, *};
+use sio::*;
 use std::{io, io::Write};
 
 extern crate test;
@@ -9,11 +9,12 @@ use test::Bencher;
 type AEAD = AES_256_GCM;
 
 fn buffer_size() -> usize {
-    if let Ok(value) = std::env::var("SIO_BUF_SIZE") {
+    const BUFFER_SIZE: &'static str = "SIO_BUF_SIZE";
+    if let Ok(value) = std::env::var(BUFFER_SIZE) {
         let value: usize = value
             .as_str()
             .parse()
-            .expect("'SIO_BUF_SIZE' is not a number");
+            .expect(format!("'{}' is not a number", BUFFER_SIZE).as_str());
         1024 * value
     } else {
         sio::BUF_SIZE


### PR DESCRIPTION


<!-- 
If you want to add a feature or fix a bug (not just typos / code style / ...),
please open an issue first such that we can discuss the feature and track bugs.
See: https://github.com/secure-io/sio-go/issues
Thank you :)
-->

#### What does the PR do?
This commit moves the name of the benchmark
env. var. from a magic string to a constant.

#### What problem does it solve?
<!-- For features and (major) bug fixes link the issue here (e.g. #42) ->




<!-- Thank you very much for contributing to this project! -->
