### PR TITLE
split `ring` feature into aesgcm and default features

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -18,5 +18,7 @@ task:
      
   cargo_cache:
      folder: $CARGO_HOME/registry
-  test_script: cargo test --verbose --all
+  test_script: 
+          - cargo test --all
+          - cargo test --all --features=aesgcm 
   before_cache_script: rm -rf $CARGO_HOME/registry/index

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,11 @@ incremental = false
 overflow-checks = false
 
 [features]
-default = ["ring"]
+default = ["c20p1305"]
+
+c20p1305 = ["ring"]
+
+aesgcm = ["ring"]
 
 # The 'debug_panic' feature prevents panicking when
 # an 'EncWriter' or 'DecWriter' gets dropped without

--- a/benches/writer.rs
+++ b/benches/writer.rs
@@ -10,7 +10,11 @@ use std::{io, io::Write};
 extern crate test;
 use test::Bencher;
 
+#[cfg(feature = "aesgcm")]
 type AEAD = AES_256_GCM;
+
+#[cfg(not(feature = "aesgcm"))]
+type AEAD = CHACHA20_POLY1305;
 
 fn buffer_size() -> usize {
     const BUFFER_SIZE: &'static str = "SIO_BUF_SIZE";

--- a/src/aesgcm.rs
+++ b/src/aesgcm.rs
@@ -4,8 +4,8 @@
 
 extern crate ring;
 
-use super::aead::Algorithm;
-use super::error::{Invalid, NotAuthentic};
+use crate::aead::Algorithm;
+use crate::error::{Invalid, NotAuthentic};
 use ring::aead;
 
 #[allow(non_camel_case_types)]
@@ -23,61 +23,6 @@ impl Algorithm for AES_256_GCM {
         Self {
             seal_key: aead::SealingKey::new(&aead::AES_256_GCM, key).unwrap(),
             open_key: aead::OpeningKey::new(&aead::AES_256_GCM, key).unwrap(),
-        }
-    }
-
-    fn seal_in_place<'a>(
-        &self,
-        nonce: &[u8; Self::NONCE_LEN],
-        aad: &[u8],
-        in_out: &'a mut [u8],
-    ) -> Result<&'a [u8], Invalid> {
-        match aead::seal_in_place(
-            &self.seal_key,
-            aead::Nonce::assume_unique_for_key(*nonce),
-            aead::Aad::from(aad),
-            in_out,
-            Self::TAG_LEN,
-        ) {
-            Ok(len) => Ok(&in_out[..len]),
-            Err(_) => Err(Invalid::BufSize),
-        }
-    }
-
-    fn open_in_place<'a>(
-        &self,
-        nonce: &[u8; Self::NONCE_LEN],
-        aad: &[u8],
-        in_out: &'a mut [u8],
-    ) -> Result<&'a [u8], NotAuthentic> {
-        match aead::open_in_place(
-            &self.open_key,
-            aead::Nonce::assume_unique_for_key(*nonce),
-            aead::Aad::from(aad),
-            0,
-            in_out,
-        ) {
-            Ok(val) => Ok(val),
-            Err(_) => Err(NotAuthentic),
-        }
-    }
-}
-
-#[allow(non_camel_case_types)]
-pub struct CHACHA20_POLY1305 {
-    seal_key: aead::SealingKey,
-    open_key: aead::OpeningKey,
-}
-
-impl Algorithm for CHACHA20_POLY1305 {
-    const KEY_LEN: usize = 256 / 8;
-    const NONCE_LEN: usize = 96 / 8;
-    const TAG_LEN: usize = 128 / 8;
-
-    fn new(key: &[u8; Self::KEY_LEN]) -> Self {
-        Self {
-            seal_key: aead::SealingKey::new(&aead::CHACHA20_POLY1305, key).unwrap(),
-            open_key: aead::OpeningKey::new(&aead::CHACHA20_POLY1305, key).unwrap(),
         }
     }
 

--- a/src/c20p1305.rs
+++ b/src/c20p1305.rs
@@ -1,0 +1,64 @@
+// Copyright (c) 2019 Andreas Auernhammer. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+extern crate ring;
+
+use crate::aead::Algorithm;
+use crate::error::{Invalid, NotAuthentic};
+use ring::aead;
+
+#[allow(non_camel_case_types)]
+pub struct CHACHA20_POLY1305 {
+    seal_key: aead::SealingKey,
+    open_key: aead::OpeningKey,
+}
+
+impl Algorithm for CHACHA20_POLY1305 {
+    const KEY_LEN: usize = 256 / 8;
+    const NONCE_LEN: usize = 96 / 8;
+    const TAG_LEN: usize = 128 / 8;
+
+    fn new(key: &[u8; Self::KEY_LEN]) -> Self {
+        Self {
+            seal_key: aead::SealingKey::new(&aead::CHACHA20_POLY1305, key).unwrap(),
+            open_key: aead::OpeningKey::new(&aead::CHACHA20_POLY1305, key).unwrap(),
+        }
+    }
+
+    fn seal_in_place<'a>(
+        &self,
+        nonce: &[u8; Self::NONCE_LEN],
+        aad: &[u8],
+        in_out: &'a mut [u8],
+    ) -> Result<&'a [u8], Invalid> {
+        match aead::seal_in_place(
+            &self.seal_key,
+            aead::Nonce::assume_unique_for_key(*nonce),
+            aead::Aad::from(aad),
+            in_out,
+            Self::TAG_LEN,
+        ) {
+            Ok(len) => Ok(&in_out[..len]),
+            Err(_) => Err(Invalid::BufSize),
+        }
+    }
+
+    fn open_in_place<'a>(
+        &self,
+        nonce: &[u8; Self::NONCE_LEN],
+        aad: &[u8],
+        in_out: &'a mut [u8],
+    ) -> Result<&'a [u8], NotAuthentic> {
+        match aead::open_in_place(
+            &self.open_key,
+            aead::Nonce::assume_unique_for_key(*nonce),
+            aead::Aad::from(aad),
+            0,
+            in_out,
+        ) {
+            Ok(val) => Ok(val),
+            Err(_) => Err(NotAuthentic),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,18 +16,21 @@
 //! <table>
 //! <tr><th>Feature
 //!     <th>Description
-//! <tr><td><code>ring (default)</code>
+//! <tr><td><code>c20p1305 (default)</code>
 //!     <td>Use <a href="https://briansmith.org/rustdoc/ring/"><code>ring</code></a> to provide
-//!     default implementations of AES-256-GCM and ChaCha20-Poly1305 based on Google's
-//!     <a href="https://github.com/google/boringssl">BoringSSL</a> by implementing the
-//!     <code>Algorithm</code> trait.
+//!     default implementation of ChaCha20-Poly1305 based on Google's <a href="https://github.com/google/boringssl">BoringSSL</a>
+//!     by implementing the <code>Algorithm</code> trait.
+//! <tr><td><code>aesgcm</code>
+//!     <td>Use <a href="https://briansmith.org/rustdoc/ring/"><code>ring</code></a> to provide
+//!     default implementation of AES-256-GCM based on Google's <a href="https://github.com/google/boringssl">BoringSSL</a>
+//!     by implementing the <code>Algorithm</code> trait.
 //! <tr><td><code>debug_panic</code>
 //!     <td>This feature only affects debug builds and should only be enabled when debugging a
 //!     panic. Both, <code>EncWriter</code> and <code>DecWriter</code> must be closed explicitly.
 //!     Otherwise, dropping them causes a panic. Take a look at the <code>Close</code> trait for
 //!     more details. When this feature is enabled, dropping an <code>EncWriter</code> or
 //!     <code>DecWriter</code> without closing it explicitly does not trigger a panic in debug mode.
-//!     This may be useful when debugging a panic of some other code.
+//!     This may be useful when debugging a panic.
 //! </table>
 //!
 //! # Introduction
@@ -138,14 +141,15 @@ mod error;
 mod utils;
 mod writer;
 
-#[cfg(feature = "ring")]
-mod ring;
+#[cfg(feature = "aesgcm")]
+mod aesgcm;
+#[cfg(feature = "aesgcm")]
+pub use self::aesgcm::AES_256_GCM;
 
-#[cfg(feature = "ring")]
-pub use self::ring::AES_256_GCM;
-
-#[cfg(feature = "ring")]
-pub use self::ring::CHACHA20_POLY1305;
+#[cfg(feature = "c20p1305")]
+mod c20p1305;
+#[cfg(feature = "c20p1305")]
+pub use self::c20p1305::CHACHA20_POLY1305;
 
 pub const MAX_BUF_SIZE: usize = (1 << 24) - 1;
 pub const BUF_SIZE: usize = 1 << 14;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -53,17 +53,17 @@ impl<W: Write + Close> Close for io::LineWriter<W> {
 ///
 /// ```
 /// use std::{io, io::Write};
-/// use sio::{Key, Nonce, Aad, EncWriter, AES_256_GCM, NopCloser};
+/// use sio::{Key, Nonce, Aad, EncWriter, CHACHA20_POLY1305, NopCloser};
 ///
 /// // Load your secret keys from a secure location or derive
 /// // them using a secure (password-based) key-derivation-function, like Argon2id.
 /// // Obviously, don't use this all-zeros key for anything real.
-/// let key: Key<AES_256_GCM> = Key::new([0; Key::<AES_256_GCM>::SIZE]);
+/// let key: Key<CHACHA20_POLY1305> = Key::new([0; Key::<CHACHA20_POLY1305>::SIZE]);
 ///
 /// // Make sure you use an unique key-nonce combination!
 /// // Reusing a nonce value for the same secret key breaks
 /// // the security of the encryption algorithm.
-/// let nonce = Nonce::new([0; Nonce::<AES_256_GCM>::SIZE]);
+/// let nonce = Nonce::new([0; Nonce::<CHACHA20_POLY1305>::SIZE]);
 ///
 /// // You must be able to re-generate this aad to decrypt
 /// // the ciphertext again. Usually, it's stored together with

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -29,17 +29,17 @@ use std::io::Write;
 ///
 /// ```
 /// use std::io::Write;
-/// use sio::{Key, Nonce, Aad, EncWriter, AES_256_GCM};
+/// use sio::{Key, Nonce, Aad, EncWriter, CHACHA20_POLY1305};
 ///
 /// // Load your secret keys from a secure location or derive
 /// // them using a secure (password-based) key-derivation-function, like Argon2id.
 /// // Obviously, don't use this all-zeros key for anything real.
-/// let key: Key<AES_256_GCM> = Key::new([0; Key::<AES_256_GCM>::SIZE]);
+/// let key: Key<CHACHA20_POLY1305> = Key::new([0; Key::<CHACHA20_POLY1305>::SIZE]);
 ///
 /// // Make sure you use an unique key-nonce combination!
 /// // Reusing a nonce value for the same secret key breaks
 /// // the security of the encryption algorithm.
-/// let nonce = Nonce::new([0; Nonce::<AES_256_GCM>::SIZE]);
+/// let nonce = Nonce::new([0; Nonce::<CHACHA20_POLY1305>::SIZE]);
 ///
 /// // You must be able to re-generate this aad to decrypt
 /// // the ciphertext again. Usually, it's stored together with
@@ -90,17 +90,17 @@ impl<A: Algorithm, W: Write + internal::Close> EncWriter<A, W> {
     ///
     /// ```
     /// use std::io::Write;
-    /// use sio::{Key, Nonce, Aad, EncWriter, AES_256_GCM};
+    /// use sio::{Key, Nonce, Aad, EncWriter, CHACHA20_POLY1305};
     ///
     /// // Load your secret keys from a secure location or derive
     /// // them using a secure (password-based) key-derivation-function, like Argon2id.
     /// // Obviously, don't use this all-zeros key for anything real.
-    /// let key: Key<AES_256_GCM> = Key::new([0; Key::<AES_256_GCM>::SIZE]);
+    /// let key: Key<CHACHA20_POLY1305> = Key::new([0; Key::<CHACHA20_POLY1305>::SIZE]);
     ///
     /// // Make sure you use an unique key-nonce combination!
     /// // Reusing a nonce value for the same secret key breaks
     /// // the security of the encryption algorithm.
-    /// let nonce = Nonce::new([0; Nonce::<AES_256_GCM>::SIZE]);
+    /// let nonce = Nonce::new([0; Nonce::<CHACHA20_POLY1305>::SIZE]);
     ///
     /// // You must be able to re-generate this aad to decrypt
     /// // the ciphertext again. Usually, it's stored together with
@@ -137,17 +137,17 @@ impl<A: Algorithm, W: Write + internal::Close> EncWriter<A, W> {
     ///
     /// ```
     /// use std::io::Write;
-    /// use sio::{Key, Nonce, Aad, EncWriter, AES_256_GCM};
+    /// use sio::{Key, Nonce, Aad, EncWriter, CHACHA20_POLY1305};
     ///
     /// // Load your secret keys from a secure location or derive
     /// // them using a secure (password-based) key-derivation-function, like Argon2id.
     /// // Obviously, don't use this all-zeros key for anything real.
-    /// let key: Key<AES_256_GCM> = Key::new([0; Key::<AES_256_GCM>::SIZE]);
+    /// let key: Key<CHACHA20_POLY1305> = Key::new([0; Key::<CHACHA20_POLY1305>::SIZE]);
     ///
     /// // Make sure you use an unique key-nonce combination!
     /// // Reusing a nonce value for the same secret key breaks
     /// // the security of the encryption algorithm.
-    /// let nonce = Nonce::new([0; Nonce::<AES_256_GCM>::SIZE]);
+    /// let nonce = Nonce::new([0; Nonce::<CHACHA20_POLY1305>::SIZE]);
     ///
     /// // You must be able to re-generate this aad to decrypt
     /// // the ciphertext again. Usually, it's stored together with
@@ -353,15 +353,15 @@ impl<A: Algorithm, W: Write + internal::Close> Drop for EncWriter<A, W> {
 ///
 /// ```
 /// use std::io::Write;
-/// use sio::{Key, Nonce, Aad, DecWriter, AES_256_GCM};
+/// use sio::{Key, Nonce, Aad, DecWriter, CHACHA20_POLY1305};
 ///
 /// // Load your secret keys from a secure location or derive
 /// // them using a secure (password-based) key-derivation-function, like Argon2id.
 /// // Obviously, don't use this all-zeros key for anything real.
-/// let key: Key<AES_256_GCM> = Key::new([0; Key::<AES_256_GCM>::SIZE]);
+/// let key: Key<CHACHA20_POLY1305> = Key::new([0; Key::<CHACHA20_POLY1305>::SIZE]);
 ///
 /// // Use the same nonce that was used during encryption.
-/// let nonce = Nonce::new([0; Nonce::<AES_256_GCM>::SIZE]);
+/// let nonce = Nonce::new([0; Nonce::<CHACHA20_POLY1305>::SIZE]);
 ///
 /// // Use the same associated data (AAD) that was used during encryption.
 /// let aad = Aad::from("Some authenticated but not encrypted data".as_bytes());
@@ -370,9 +370,9 @@ impl<A: Algorithm, W: Write + internal::Close> Drop for EncWriter<A, W> {
 /// let mut writer = DecWriter::new(&mut plaintext, &key, nonce, aad);
 ///
 /// // Passing the ciphertext as raw bytes.
-/// writer.write(&[14, 95, 207, 89, 77, 7, 174, 168, 96, 128, 148, 207, 224,
-///                86, 236, 153 ,177, 220, 133, 123, 145, 175, 149, 241, 197,
-///                153, 28, 234, 143, 173, 101,243,33]).unwrap();
+/// writer.write(&[17, 137, 205, 68, 28, 113, 101, 52, 193, 68, 213, 16, 104,
+///                80, 203, 255, 183, 120, 46, 225, 192, 178, 253, 57, 67, 75,
+///                53, 57, 45, 94]).unwrap();
 ///
 /// writer.close().unwrap(); // Complete the decryption process explicitly!
 ///
@@ -414,15 +414,15 @@ impl<A: Algorithm, W: Write + internal::Close> DecWriter<A, W> {
     ///
     /// ```
     /// use std::io::Write;
-    /// use sio::{Key, Nonce, Aad, DecWriter, AES_256_GCM};
+    /// use sio::{Key, Nonce, Aad, DecWriter, CHACHA20_POLY1305};
     ///
     /// // Load your secret keys from a secure location or derive
     /// // them using a secure (password-based) key-derivation-function, like Argon2id.
     /// // Obviously, don't use this all-zeros key for anything real.
-    /// let key: Key<AES_256_GCM> = Key::new([0; Key::<AES_256_GCM>::SIZE]);
+    /// let key: Key<CHACHA20_POLY1305> = Key::new([0; Key::<CHACHA20_POLY1305>::SIZE]);
     ///
     /// // Use the same nonce that was used during encryption.
-    /// let nonce = Nonce::new([0; Nonce::<AES_256_GCM>::SIZE]);
+    /// let nonce = Nonce::new([0; Nonce::<CHACHA20_POLY1305>::SIZE]);
     ///
     /// // Use the same associated data (AAD) that was used during encryption.
     /// let aad = Aad::from("Some authenticated but not encrypted data".as_bytes());
@@ -433,9 +433,9 @@ impl<A: Algorithm, W: Write + internal::Close> DecWriter<A, W> {
     /// // Perform some write and flush operations
     /// // ...
     /// // For example:
-    /// writer.write(&[14, 95, 207, 89, 77, 7, 174, 168, 96, 128, 148, 207, 224,
-    ///                86, 236, 153 ,177, 220, 133, 123, 145, 175, 149, 241, 197,
-    ///                153, 28, 234, 143, 173, 101,243,33]).unwrap();
+    /// writer.write(&[17, 137, 205, 68, 28, 113, 101, 52, 193, 68, 213, 16, 104,
+    ///                80, 203, 255, 183, 120, 46, 225, 192, 178, 253, 57, 67, 75,
+    ///                53, 57, 45, 94]).unwrap();
     ///
     /// writer.close().unwrap(); // Complete the decryption process explicitly!
     ///
@@ -464,15 +464,15 @@ impl<A: Algorithm, W: Write + internal::Close> DecWriter<A, W> {
     ///
     /// ```
     /// use std::io::Write;
-    /// use sio::{Key, Nonce, Aad, DecWriter, AES_256_GCM};
+    /// use sio::{Key, Nonce, Aad, DecWriter, CHACHA20_POLY1305};
     ///
     /// // Load your secret keys from a secure location or derive
     /// // them using a secure (password-based) key-derivation-function, like Argon2id.
     /// // Obviously, don't use this all-zeros key for anything real.
-    /// let key: Key<AES_256_GCM> = Key::new([0; Key::<AES_256_GCM>::SIZE]);
+    /// let key: Key<CHACHA20_POLY1305> = Key::new([0; Key::<CHACHA20_POLY1305>::SIZE]);
     ///
     /// // Use the same nonce that was used for encryption.
-    /// let nonce = Nonce::new([0; Nonce::<AES_256_GCM>::SIZE]);
+    /// let nonce = Nonce::new([0; Nonce::<CHACHA20_POLY1305>::SIZE]);
     ///
     /// // Use the same associated data (AAD) that was used for encryption.
     /// let aad = Aad::from("Some authenticated but not encrypted data".as_bytes());
@@ -490,9 +490,9 @@ impl<A: Algorithm, W: Write + internal::Close> DecWriter<A, W> {
     /// // Perform some write and flush operations
     /// // ...
     /// // For example:
-    /// writer.write(&[14, 95, 207, 89, 77, 7, 174, 168, 96, 128, 148, 207, 224,
-    ///                86, 236, 153 ,177, 220, 133, 123, 145, 175, 149, 241, 197,
-    ///                153, 28, 234, 143, 173, 101,243,33]).unwrap();
+    /// writer.write(&[17, 137, 205, 68, 28, 113, 101, 52, 193, 68, 213, 16, 104,
+    ///                80, 203, 255, 183, 120, 46, 225, 192, 178, 253, 57, 67, 75,
+    ///                53, 57, 45, 94]).unwrap();
     ///
     /// writer.close().unwrap(); // Complete the decryption process explicitly!
     ///
@@ -703,23 +703,23 @@ mod internal {
 /// calling the `close` method of the outer `EncWriter`. You can achieve this by calling the
 /// `closer` method.
 /// ```
-/// use sio::{Aad, EncWriter, Key, Nonce, AES_256_GCM};
+/// use sio::{Aad, EncWriter, Key, Nonce, CHACHA20_POLY1305};
 /// use std::io;
 ///
 /// fn main() -> io::Result<()> {
-///    let outer_key: Key<AES_256_GCM> = Key::new([0; Key::<AES_256_GCM>::SIZE]);
-///    let inner_key: Key<AES_256_GCM> = Key::new([1; Key::<AES_256_GCM>::SIZE]);
+///    let outer_key: Key<CHACHA20_POLY1305> = Key::new([0; Key::<CHACHA20_POLY1305>::SIZE]);
+///    let inner_key: Key<CHACHA20_POLY1305> = Key::new([1; Key::<CHACHA20_POLY1305>::SIZE]);
 ///
 ///    let writer = EncWriter::new(
 ///        io::BufWriter::new(EncWriter::new(
 ///            io::sink(),
 ///            &inner_key,
-///            Nonce::new([0; Nonce::<AES_256_GCM>::SIZE]),
+///            Nonce::new([0; Nonce::<CHACHA20_POLY1305>::SIZE]),
 ///            Aad::empty(),
 ///        ).closer() // Without this `closer` call the code would not compile.
 ///        ),
 ///        &outer_key,
-///        Nonce::new([0; Nonce::<AES_256_GCM>::SIZE]),
+///        Nonce::new([0; Nonce::<CHACHA20_POLY1305>::SIZE]),
 ///        Aad::empty(),
 ///    );
 ///


### PR DESCRIPTION


<!-- 
If you want to add a feature or fix a bug (not just typos / code style / ...),
please open an issue first such that we can discuss the feature and track bugs.
See: https://github.com/secure-io/sio-go/issues
Thank you :)
-->

#### What does the PR do?
This commit splits the `ring` feature into to features:
 - `aesgcm`
 - `c20p1305`

By default `c20p1305` is enabled while users must opt-in
to `aesgcm` since c20p1305 should be more resistant against
side-channel attacks (timing) on hardware without AES-NI.

Therefore, all tests and examples move to `CHACHA20_POLY1305`
by default - but unit tests and benchmarks use `AES_256_GCM`
when the `aesgcm` feature is enabled.

#### What problem does it solve?
<!-- For features and (major) bug fixes link the issue here (e.g. #42) ->




<!-- Thank you very much for contributing to this project! -->
