### PR TITLE
check for panic during drop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,23 +21,7 @@ overflow-checks = false
 default = ["c20p1305"]
 
 c20p1305 = ["ring"]
-
 aesgcm = ["ring"]
-
-# The 'debug_panic' feature prevents panicking when
-# an 'EncWriter' or 'DecWriter' gets dropped without
-# being closed explicitly - in debug mode. It has no
-# effect in release mode. The purpose of this feature
-# is to debug a panic caused by some other code. If 
-# that panic occurs while an 'EncWriter' or 'DecWriter'
-# has not been closed (yet) then the close call will be
-# skipped but the writer may get dropped (unwinding) - 
-# which then causes another panic. 
-#
-# This feature should only be enabled when debugging a
-# panic.
-debug_panic = []
-
 
 [dependencies]
 ring = { version = "0.14.6", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,13 +24,6 @@
 //!     <td>Use <a href="https://briansmith.org/rustdoc/ring/"><code>ring</code></a> to provide
 //!     default implementation of AES-256-GCM based on Google's <a href="https://github.com/google/boringssl">BoringSSL</a>
 //!     by implementing the <code>Algorithm</code> trait.
-//! <tr><td><code>debug_panic</code>
-//!     <td>This feature only affects debug builds and should only be enabled when debugging a
-//!     panic. Both, <code>EncWriter</code> and <code>DecWriter</code> must be closed explicitly.
-//!     Otherwise, dropping them causes a panic. Take a look at the <code>Close</code> trait for
-//!     more details. When this feature is enabled, dropping an <code>EncWriter</code> or
-//!     <code>DecWriter</code> without closing it explicitly does not trigger a panic in debug mode.
-//!     This may be useful when debugging a panic.
 //! </table>
 //!
 //! # Introduction

--- a/tests/closer_tests.rs
+++ b/tests/closer_tests.rs
@@ -1,0 +1,129 @@
+// Copyright (c) 2019 Andreas Auernhammer. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+use sio::*;
+use std::{io, io::Write};
+
+#[cfg(feature = "aesgcm")]
+type AEAD = AES_256_GCM;
+
+#[cfg(not(feature = "aesgcm"))]
+type AEAD = CHACHA20_POLY1305;
+
+struct BadSink;
+
+impl io::Write for BadSink {
+    fn write(&mut self, _b: &[u8]) -> io::Result<usize> {
+        Err(io::Error::from(io::ErrorKind::Other))
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Err(io::Error::from(io::ErrorKind::Other))
+    }
+}
+
+impl Close for BadSink {
+    fn close(&mut self) -> io::Result<()> {
+        Err(io::Error::from(io::ErrorKind::Other))
+    }
+}
+
+#[test]
+#[should_panic]
+fn enc_writer_missing_close() {
+    let key: Key<AEAD> = Key::new([0; Key::<AEAD>::SIZE]);
+    let _ = EncWriter::new(
+        Vec::default(),
+        &key,
+        Nonce::new([0; Nonce::<AEAD>::SIZE]),
+        Aad::empty(),
+    );
+}
+
+#[test]
+#[should_panic]
+fn enc_writer_missing_close_after_write() {
+    let key: Key<AEAD> = Key::new([0; Key::<AEAD>::SIZE]);
+    let mut writer = EncWriter::new(
+        Vec::default(),
+        &key,
+        Nonce::new([0; Nonce::<AEAD>::SIZE]),
+        Aad::empty(),
+    );
+    let _ = writer.write_all(b"Hello World");
+}
+
+#[test]
+fn enc_writer_missing_close_after_error() {
+    let key: Key<AEAD> = Key::new([0; Key::<AEAD>::SIZE]);
+    let mut writer = EncWriter::new(
+        BadSink,
+        &key,
+        Nonce::new([0; Nonce::<AEAD>::SIZE]),
+        Aad::empty(),
+    );
+    let _ = writer.write_all(&[0; BUF_SIZE + 1]);
+}
+
+#[test]
+#[should_panic]
+fn enc_writer_missing_close_after_panic() {
+    let key: Key<AEAD> = Key::new([0; Key::<AEAD>::SIZE]);
+    let _ = EncWriter::new(
+        Vec::default(),
+        &key,
+        Nonce::new([0; Nonce::<AEAD>::SIZE]),
+        Aad::empty(),
+    );
+    panic!();
+}
+
+#[test]
+#[should_panic]
+fn dec_writer_missing_close() {
+    let key: Key<AEAD> = Key::new([0; Key::<AEAD>::SIZE]);
+    let _ = DecWriter::new(
+        Vec::default(),
+        &key,
+        Nonce::new([0; Nonce::<AEAD>::SIZE]),
+        Aad::empty(),
+    );
+}
+
+#[test]
+#[should_panic]
+fn dec_writer_missing_close_after_write() {
+    let key: Key<AEAD> = Key::new([0; Key::<AEAD>::SIZE]);
+    let mut writer = DecWriter::new(
+        Vec::default(),
+        &key,
+        Nonce::new([0; Nonce::<AEAD>::SIZE]),
+        Aad::empty(),
+    );
+    let _ = writer.write_all(b"Hello World");
+}
+
+#[test]
+fn dec_writer_missing_close_after_error() {
+    let key: Key<AEAD> = Key::new([0; Key::<AEAD>::SIZE]);
+    let mut writer = DecWriter::new(
+        io::sink(),
+        &key,
+        Nonce::new([0; Nonce::<AEAD>::SIZE]),
+        Aad::empty(),
+    );
+    let _ = writer.write_all(&[0; BUF_SIZE + AEAD::TAG_LEN + 1]);
+}
+
+#[test]
+#[should_panic]
+fn dec_writer_missing_close_after_panic() {
+    let key: Key<AEAD> = Key::new([0; Key::<AEAD>::SIZE]);
+    let _ = DecWriter::new(
+        Vec::default(),
+        &key,
+        Nonce::new([0; Nonce::<AEAD>::SIZE]),
+        Aad::empty(),
+    );
+    panic!();
+}


### PR DESCRIPTION


<!-- 
If you want to add a feature or fix a bug (not just typos / code style / ...),
please open an issue first such that we can discuss the feature and track bugs.
See: https://github.com/secure-io/sio-go/issues
Thank you :)
-->

#### What does the PR do?
This commit replaces the manual panic
tracking with `std::thread::panicking()`.

This eliminates the need for the `debug_panic`
feature which is also removed by this commit.

In addition this commit fixes the `write_buffer`
implementations to set the `errored` flag correctly.
In particular, the `errored` flag is now set when no
more nonces are available, en/decrypting fails or when
writing to the underlying writer fails.

A new set of unit tests ensures that `EncWriter` and `DecWriter`
behave as expected when not closed.

#### What problem does it solve?
<!-- For features and (major) bug fixes link the issue here (e.g. #42) ->




<!-- Thank you very much for contributing to this project! -->
